### PR TITLE
check md5 and length of downloads

### DIFF
--- a/ql-https.lisp
+++ b/ql-https.lisp
@@ -19,8 +19,10 @@
       (let ((output (uiop:run-program (format nil "curl -fsSL ~A -o ~A" url file)
                                       :output '(:string :stripped t)
                                       :error-output :output))
-            (file (and file (probe-file file))))
-        (verify-download file (url-to-release url))
+            (file (and file (probe-file file)))
+            (release (url-to-release url)))
+        (when release
+          (verify-download file release))
         (values output file))
       (restart-case
           (handler-bind ((error (lambda (c)
@@ -41,9 +43,10 @@
 
 (defun url-to-release (url)
   "extracts name of release from URL"
-  (let* ((start (+ (search "/archive/" url) (length "/archive/")))
-         (end (position #\/ url :start start)))
-    (subseq url start end)))
+  (when (search "/archive/" url)
+    (let* ((start (+ (search "/archive/" url) (length "/archive/")))
+           (end (position #\/ url :start start)))
+      (subseq url start end))))
 
 (defun md5 (file)
   "Returns md5sum of FILE"

--- a/ql-https.lisp
+++ b/ql-https.lisp
@@ -16,10 +16,12 @@
   "Fetch URL and safe it to FILE."
   (declare (ignorable args))
   (if (uiop:string-prefix-p "https://" url)
-      (values (uiop:run-program (format nil "curl -fsSL ~A -o ~A" url file)
-                                :output '(:string :stripped t)
-                                :error-output :output)
-              (and file (probe-file file)))
+      (let ((output (uiop:run-program (format nil "curl -fsSL ~A -o ~A" url file)
+                                      :output '(:string :stripped t)
+                                      :error-output :output))
+            (file (and file (probe-file file))))
+        (verify-download file (url-to-release url))
+        (values output file))
       (restart-case
           (handler-bind ((error (lambda (c)
                                   (declare (ignore c))
@@ -37,6 +39,30 @@
           (setf *quietly-use-https* t)
           (apply #'fetcher url file args)))))
 
+(defun url-to-release (url)
+  "extracts name of release from URL"
+  (let* ((start (+ (search "/archive/" url) (length "/archive/")))
+         (end (position #\/ url :start start)))
+    (subseq url start end)))
+
+(defun md5 (file)
+  "Returns md5sum of FILE"
+  (uiop:run-program (format nil "md5sum \"~A\" | cut -d' ' -f 1" file)
+                    :output '(:string :stripped t)))
+
+(defun file-size (file)
+  "Returns the size of FILE in bytes"
+  (with-open-file (f file)
+    (file-length f)))
+
+(defun verify-download (file name)
+  "Checks that the md5 and size of FILE are as expected from the quicklisp
+dist."
+  (let ((release (ql-dist:find-release name)))
+    (unless (string= (ql-dist:archive-md5 release) (md5 file))
+      (error "md5 mismatch for ~A" name))
+    (unless (= (ql-dist:archive-size release) (file-size file))
+      (error "file size mismatch for ~A" name))))
 
 (defun register-fetch-scheme-functions ()
   (setf ql-http:*fetch-scheme-functions*


### PR DESCRIPTION
Since the quicklisp release contains the md5 and length of files, I figured we might as well check it when downloading. In the same spirit of `ql-https` just shelling out to curl, I just shell out to `md5sum` which is present on 99.9% of unix boxes.

If md5 was secure it would add significant security. Rather than getting a certificate authority to issue a false certificate or temporarily compromising the quicklisp server and backdooring some package, an attacker would have to also edit the dist to match their new hash and maintain the compromise unnoticed for months until you download the new dist and update some package. Unfortunately md5 is not secure and it's possible to make collisions with the same length, but it at least makes it a little harder for an attacker, and if quicklisp ever changes to use sha256sum or something then it will be trivial to change here and actually provide significant extra security. The quicklisp dist also contains a sha1 which would be better than md5, but that is generated by git which uses the time and author of the commit among other information we don't have in the simple release .tgz, so I don't think we can check it.