### PR TITLE
Install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ environment variable, for example to use Clozure common lisp:
 
 now run the installer script:
 
-    curl https://raw.githubusercontent.com/rudolfochrist/ql-https/install-script/install.sh | bash
+    curl https://raw.githubusercontent.com/rudolfochrist/ql-https/master/install.sh | bash
 
 
 ## MANUAL INSTALLATION

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ ql-https &#x2014; HTTPS support for Quicklisp via curl
 
 ## AUTOMATIC INSTALLATION
 
-The default implementation is sbcl, if you are using another then set the `LANG`
+The default implementation is sbcl, if you are using another then set the `LISP`
 environment variable, for example to use Clozure common lisp:
 
-    export LANG=ccl
+    export LISP=ccl
 
 now run the installer script:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,19 @@ ql-https &#x2014; HTTPS support for Quicklisp via curl
 -   curl (refer to your system package manager)
 
 
-## INSTALLATION
+## AUTOMATIC INSTALLATION
+
+The default implementation is sbcl, if you are using another then set the `LANG`
+environment variable, for example to use Clozure common lisp:
+
+    export LANG=ccl
+
+now run the installer script:
+
+    curl https://raw.githubusercontent.com/rudolfochrist/ql-https/install-script/install.sh | bash
+
+
+## MANUAL INSTALLATION
 
 1.  `mkdir ~/quicklisp` and `cd ~/quicklisp`
 2.  Go to <https://beta.quicklisp.org/client/quicklisp.sexp> and lookup `:client-tar` URL, download it, verify

--- a/doc/README.org
+++ b/doc/README.org
@@ -26,10 +26,10 @@ cat ../version
 - curl (refer to your system package manager)
   
 ** AUTOMATIC INSTALLATION
-The default implementation is sbcl, if you are using another then set the ~LANG~
+The default implementation is sbcl, if you are using another then set the ~LISP~
 environment variable, for example to use Clozure common lisp:
-#+begin_src lisp
-export LANG=ccl
+#+begin_src sh
+export LISP=ccl
 #+end_src
 now run the installer script:
 #+begin_src sh

--- a/doc/README.org
+++ b/doc/README.org
@@ -25,7 +25,18 @@ cat ../version
 - [[https://www.quicklisp.org/beta/][Quicklisp]]
 - curl (refer to your system package manager)
   
-** INSTALLATION
+** AUTOMATIC INSTALLATION
+The default implementation is sbcl, if you are using another then set the ~LANG~
+environment variable, for example to use Clozure common lisp:
+#+begin_src lisp
+export LANG=ccl
+#+end_src
+now run the installer script:
+#+begin_src sh
+curl https://raw.githubusercontent.com/rudolfochrist/ql-https/install-script/install.sh | bash
+#+end_src
+
+** MANUAL INSTALLATION
 
 1. =mkdir ~/quicklisp= and =cd ~/quicklisp=
 2. Go to [[https://beta.quicklisp.org/client/quicklisp.sexp]] and lookup =:client-tar= URL, download it, verify

--- a/doc/README.org
+++ b/doc/README.org
@@ -33,7 +33,7 @@ export LANG=ccl
 #+end_src
 now run the installer script:
 #+begin_src sh
-curl https://raw.githubusercontent.com/rudolfochrist/ql-https/install-script/install.sh | bash
+curl https://raw.githubusercontent.com/rudolfochrist/ql-https/master/install.sh | bash
 #+end_src
 
 ** MANUAL INSTALLATION

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+LISP=${LISP=sbcl}
+
+echo "Downloading quicklisp metadata..."
+mkdir -p ~/quicklisp
+meta=$( curl -s https://beta.quicklisp.org/client/quicklisp.sexp | \
+        awk '/:client-tar/,/)/' | tr '\n' ' ' | sed -e's/\s\+/ /g' )
+
+url=$( grep -oP '(?<=:url ")[^"]*' <<< "$meta" )
+sha256=$( grep -oP '(?<=:sha256 ")[^"]*' <<< "$meta" )
+
+echo "Downloading quicklisp client..."
+curl -s "$url" -o ~/quicklisp/quicklisp.tar
+
+if [ "$sha256" != "$(sha256sum ~/quicklisp/quicklisp.tar  | cut -d' ' -f 1)" ]
+then
+   echo "sha mismatch" >&2
+   exit 1
+fi
+
+tar xf ~/quicklisp/quicklisp.tar -C ~/quicklisp
+rm ~/quicklisp/quicklisp.tar
+
+echo "Cloning ql-https..."
+git clone https://github.com/rudolfochrist/ql-https ~/common-lisp/ql-https
+
+echo "Running setup code..."
+$LISP <<EOF
+(require 'asdf)
+(load "~/common-lisp/ql-https/ql-setup.lisp")
+(asdf:load-system "ql-https")
+(assert (equalp ql-http:*fetch-scheme-functions* '(("http" . ql-https:fetcher) ("https" . ql-https:fetcher))))
+(setf ql-https:*quietly-use-https* t)
+(quicklisp:setup)
+(ql-util:without-prompting
+  (ql:add-to-init-file))
+EOF
+
+cat > ~/quicklisp/setup.lisp <<EOF
+(require 'asdf)
+(let ((quicklisp-init #p"~/common-lisp/ql-https/ql-setup.lisp"))
+  (when (probe-file quicklisp-init)
+    (load quicklisp-init)
+    (asdf:load-system "ql-https")
+    (uiop:symbol-call :quicklisp :setup)))
+
+;; optional
+#+ql-https
+(setf ql-https:*quietly-use-https* t)
+EOF
+
+echo "All done!"


### PR DESCRIPTION
I made a simple bash script that just automates the installation instructions, along with writing the `ql-https` initialization to `~/quicklisp/setup.lisp`, and then calling `ql:add-to-init-file` which adds `(load "~/quicklisp/setup.lisp")` to your lisp implementations init rc file. I tested with sbcl and clozure cl. I also tried with ecl but it seems that has an error with `ql-https`, on `(load "~/common-lisp/ql-https/ql-setup.lisp")` I get:

```
;;;   ** Unable to find include directory
Condition of type: COMPILE-FILE-ERROR
COMPILE-FILE-ERROR while compiling #<cl-source-file "quicklisp" "package">

Available restarts:

1. (RETRY) Retry compiling #<cl-source-file "quicklisp" "package">.
2. (ACCEPT) Continue, treating compiling #<cl-source-file "quicklisp" "package"> as having been successful.
3. (RETRY) Retry ASDF operation.
4. (CLEAR-CONFIGURATION-AND-RETRY) Retry ASDF operation after resetting the configuration.
5. (RESTART-TOPLEVEL) Go back to Top-Level REPL.

Broken at SI:BYTECODES. [Evaluation of: (LET ((*COMPILE-PRINT* NIL) (*COMPILE-VERBOSE* NIL) (*LOAD-VERBOSE* NIL) (*LOAD-PRINT* NIL)) (ASDF/OPERATE:OOS 'ASDF/LISP-ACTION:LOAD-OP "quicklisp" :VERBOSE NIL))] In: #<process TOP-LEVEL 0x7f092d715f80>.
 File: #P"/home/user/common-lisp/ql-https/ql-setup.lisp" (Position #6509)
```