### PR TITLE
use sb-md5 if on sbcl, otherwise improve error if missing md5sum

### DIFF
--- a/ql-https.asd
+++ b/ql-https.asd
@@ -9,7 +9,7 @@
   :bug-tracker "https://github.com/rudolfochrist/ql-https/issues"
   :source-control (:git "https://github.com/rudolfochrist/ql-https.git")
   :version (:read-file-line "version")
-  :depends-on ((:require "uiop"))
+  :depends-on ((:require "uiop") (:feature :sbcl :sb-md5))
   :components ((:file "ql-https"))
   :description "Enable HTTPS in Quicklisp"
   :long-description

--- a/ql-https.lisp
+++ b/ql-https.lisp
@@ -51,7 +51,6 @@
 #+sbcl
 (defun md5 (file)
   "Returns md5sum of FILE"
-  (require 'sb-md5)
   (format nil "~{~2,'0x~}" (coerce (sb-md5:md5sum-file file) 'list)))
 
 #-sbcl

--- a/ql-https.lisp
+++ b/ql-https.lisp
@@ -48,10 +48,18 @@
            (end (position #\/ url :start start)))
       (subseq url start end))))
 
+#+sbcl
 (defun md5 (file)
   "Returns md5sum of FILE"
-  (uiop:run-program (format nil "md5sum \"~A\" | cut -d' ' -f 1" file)
-                    :output '(:string :stripped t)))
+  (require 'sb-md5)
+  (format nil "~{~2,'0x~}" (coerce (sb-md5:md5sum-file file) 'list)))
+
+#-sbcl
+(defun md5 (file)
+  "Returns md5sum of FILE"
+  (let* ((output (uiop:run-program (list "md5sum" file) :output :string))
+         (space-pos (position #\Space output)))
+    (subseq output 0 space-pos)))
 
 (defun file-size (file)
   "Returns the size of FILE in bytes"
@@ -62,7 +70,7 @@
   "Checks that the md5 and size of FILE are as expected from the quicklisp
 dist."
   (let ((release (ql-dist:find-release name)))
-    (unless (string= (ql-dist:archive-md5 release) (md5 file))
+    (unless (string-equal (ql-dist:archive-md5 release) (md5 file))
       (error "md5 mismatch for ~A" name))
     (unless (= (ql-dist:archive-size release) (file-size file))
       (error "file size mismatch for ~A" name))))

--- a/ql-https.lisp
+++ b/ql-https.lisp
@@ -57,7 +57,7 @@
 #-sbcl
 (defun md5 (file)
   "Returns md5sum of FILE"
-  (let* ((output (uiop:run-program (list "md5sum" file) :output :string))
+  (let* ((output (uiop:run-program (list "md5sum" (namestring file)) :output :string))
          (space-pos (position #\Space output)))
     (subseq output 0 space-pos)))
 


### PR DESCRIPTION
Currently it is computing md5sum by running the cli program with uiop:
```
(uiop:run-program (format nil "md5sum \"~A\" | cut -d' ' -f 1" file)
                    :output '(:string :stripped t))
```
Unfortunately in shells without `pipefail` set, if cut is present but md5sum is missing this will not return a bad error status, so uiop won't signal an error, leading to a md5-mismatch error later without a clear reason why, as in https://github.com/rudolfochrist/ql-https/issues/8

This changes it to use `sb-md5` if we are on sbcl, and if not on sbcl then still shell out to md5sum, but without piping to cut so that uiop will signal a clear error: `Couldn't execute "md5sum": No such file or directory`