### PR TITLE
Cross platform adjustments esp. md5/sha256 checksums

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ ql-https &#x2014; HTTPS support for Quicklisp via curl
 
 -   [Quicklisp](https://www.quicklisp.org/beta/)
 -   curl
--   md5sum (unless you're using SBCL)
 
 
 ## AUTOMATIC INSTALLATION

--- a/install.sh
+++ b/install.sh
@@ -3,6 +3,13 @@
 set -euo pipefail
 
 LISP=${LISP=sbcl}
+QL_TOPDIR="${QL_TOPDIR-$HOME/quicklisp}"
+
+if test -d "$QL_TOPDIR"; then
+    echo "Cannot install Quicklisp because it seems it is already installed!"
+    echo "Please check $QL_TOPDIR"
+    exit 1
+fi
 
 echo "Downloading quicklisp metadata..."
 mkdir -p ~/quicklisp

--- a/install.sh
+++ b/install.sh
@@ -16,8 +16,8 @@ mkdir -p "$QL_TOPDIR"
 meta=$( curl -s https://beta.quicklisp.org/client/quicklisp.sexp | \
             awk '/:client-tar/,/)/' | tr '\n' ' ' | tr -s ' ' )
 
-url=$( grep -oP '(?<=:url ")[^"]*' <<< "$meta" )
-sha256=$( grep -oP '(?<=:sha256 ")[^"]*' <<< "$meta" )
+url=$( perl -nle 'print $& if m{(?<=:url ")[^"]*}g' <<< "$meta" )
+sha256=$( perl -nle 'print $& if m{(?<=:sha256 ")[^"]*}g' <<< "$meta" )
 
 echo "Downloading quicklisp client..."
 curl -s "$url" -o "$QL_TOPDIR"/quicklisp.tar

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ fi
 echo "Downloading quicklisp metadata..."
 mkdir -p "$QL_TOPDIR"
 meta=$( curl -s https://beta.quicklisp.org/client/quicklisp.sexp | \
-            awk '/:client-tar/,/)/' | tr '\n' ' ' | sed -e's/\s\+/ /g' )
+            awk '/:client-tar/,/)/' | tr '\n' ' ' | tr -s ' ' )
 
 url=$( grep -oP '(?<=:url ")[^"]*' <<< "$meta" )
 sha256=$( grep -oP '(?<=:sha256 ")[^"]*' <<< "$meta" )

--- a/install.sh
+++ b/install.sh
@@ -12,24 +12,24 @@ if test -d "$QL_TOPDIR"; then
 fi
 
 echo "Downloading quicklisp metadata..."
-mkdir -p ~/quicklisp
+mkdir -p "$QL_TOPDIR"
 meta=$( curl -s https://beta.quicklisp.org/client/quicklisp.sexp | \
-        awk '/:client-tar/,/)/' | tr '\n' ' ' | sed -e's/\s\+/ /g' )
+            awk '/:client-tar/,/)/' | tr '\n' ' ' | sed -e's/\s\+/ /g' )
 
 url=$( grep -oP '(?<=:url ")[^"]*' <<< "$meta" )
 sha256=$( grep -oP '(?<=:sha256 ")[^"]*' <<< "$meta" )
 
 echo "Downloading quicklisp client..."
-curl -s "$url" -o ~/quicklisp/quicklisp.tar
+curl -s "$url" -o "$QL_TOPDIR"/quicklisp.tar
 
-if [ "$sha256" != "$(sha256sum ~/quicklisp/quicklisp.tar  | cut -d' ' -f 1)" ]
+if [ "$sha256" != "$(sha256sum "$QL_TOPDIR"/quicklisp.tar  | cut -d' ' -f 1)" ]
 then
-   echo "sha mismatch" >&2
-   exit 1
+    echo "sha mismatch" >&2
+    exit 1
 fi
 
-tar xf ~/quicklisp/quicklisp.tar -C ~/quicklisp
-rm ~/quicklisp/quicklisp.tar
+tar xf "$QL_TOPDIR"/quicklisp.tar -C "$QL_TOPDIR"
+rm "$QL_TOPDIR"/quicklisp.tar
 
 echo "Cloning ql-https..."
 git clone https://github.com/rudolfochrist/ql-https ~/common-lisp/ql-https
@@ -46,7 +46,7 @@ $LISP <<EOF
   (ql:add-to-init-file))
 EOF
 
-cat > ~/quicklisp/setup.lisp <<EOF
+cat > "$QL_TOPDIR"/setup.lisp <<EOF
 (require 'asdf)
 (let ((quicklisp-init #p"~/common-lisp/ql-https/ql-setup.lisp"))
   (when (probe-file quicklisp-init)

--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,7 @@ sha256=$( perl -nle 'print $& if m{(?<=:sha256 ")[^"]*}g' <<< "$meta" )
 echo "Downloading quicklisp client..."
 curl -s "$url" -o "$QL_TOPDIR"/quicklisp.tar
 
-if [ "$sha256" != "$(sha256sum "$QL_TOPDIR"/quicklisp.tar  | cut -d' ' -f 1)" ]
+if [ "$sha256" != "$(openssl dgst -sha256 "$QL_TOPDIR"/quicklisp.tar  | cut -d' ' -f 2)" ]
 then
     echo "sha mismatch" >&2
     exit 1

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,10 @@
 set -euo pipefail
 
 LISP=${LISP=sbcl}
+
+# For testers
 QL_TOPDIR="${QL_TOPDIR-$HOME/quicklisp}"
+CLDIR="${CLDIR-$HOME/common-lisp}"
 
 if test -d "$QL_TOPDIR"; then
     echo "Cannot install Quicklisp because it seems it is already installed!"
@@ -32,7 +35,7 @@ tar xf "$QL_TOPDIR"/quicklisp.tar -C "$QL_TOPDIR"
 rm "$QL_TOPDIR"/quicklisp.tar
 
 echo "Cloning ql-https..."
-git clone https://github.com/rudolfochrist/ql-https ~/common-lisp/ql-https
+git clone https://github.com/rudolfochrist/ql-https "$CLDIR"/ql-https
 
 echo "Running setup code..."
 $LISP <<EOF

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@ LISP=${LISP=sbcl}
 # For testers
 QL_TOPDIR="${QL_TOPDIR-$HOME/quicklisp}"
 CLDIR="${CLDIR-$HOME/common-lisp}"
+SKIP_USERINIT="${SKIP_USERINIT-no}"
 
 if test -d "$QL_TOPDIR"; then
     echo "Cannot install Quicklisp because it seems it is already installed!"
@@ -37,8 +38,9 @@ rm "$QL_TOPDIR"/quicklisp.tar
 echo "Cloning ql-https..."
 git clone https://github.com/rudolfochrist/ql-https "$CLDIR"/ql-https
 
-echo "Running setup code..."
-$LISP <<EOF
+if test "$SKIP_USERINIT" = no; then
+    echo "Running setup code..."
+    $LISP <<EOF
 (require 'asdf)
 (load "~/common-lisp/ql-https/ql-setup.lisp")
 (asdf:load-system "ql-https")
@@ -49,7 +51,7 @@ $LISP <<EOF
   (ql:add-to-init-file))
 EOF
 
-cat > "$QL_TOPDIR"/setup.lisp <<EOF
+    cat > "$QL_TOPDIR"/setup.lisp <<EOF
 (require 'asdf)
 (let ((quicklisp-init #p"~/common-lisp/ql-https/ql-setup.lisp"))
   (when (probe-file quicklisp-init)
@@ -61,5 +63,6 @@ cat > "$QL_TOPDIR"/setup.lisp <<EOF
 #+ql-https
 (setf ql-https:*quietly-use-https* t)
 EOF
+fi
 
 echo "All done!"

--- a/ql-https.lisp
+++ b/ql-https.lisp
@@ -56,9 +56,10 @@
 #-sbcl
 (defun md5 (file)
   "Returns md5sum of FILE"
-  (let* ((output (uiop:run-program (list "md5sum" (namestring file)) :output :string))
+  (let* ((output (uiop:run-program (list "openssl" "dgst" "-md5" (namestring file))
+                                   :output '(:string :stripped t)))
          (space-pos (position #\Space output)))
-    (subseq output 0 space-pos)))
+    (subseq output (1+ space-pos))))    ; exclude space itself
 
 (defun file-size (file)
   "Returns the size of FILE in bytes"


### PR DESCRIPTION
Some adjustments to handle platform-dependent programs (not just macos):

- Use openssl to verify md5 and sha256 checksums
- Use perl instead of `grep -P` 
- Change install locations with env vars. Makes testing a little easier and doesn't mess with any existing Quicklisp etc installations. 

I've tested wit CCL on macos and ECL on ubuntu. 

This solves #11 

@bo-tato Could you do me a favor and have a look over those changes before I merge them in? Thanks in advance. 