### PR TITLE
Check sha1

### DIFF
--- a/content-hash.lisp
+++ b/content-hash.lisp
@@ -1,0 +1,128 @@
+;; copied from tarhash.lisp from quicklisp-controller: https://github.com/quicklisp/quicklisp-controller
+;; changed to use openssl to compute sha1 digest rather than depending on ironclad
+
+(in-package #:ql-https)
+
+(defconstant +block-octet-count+ 512)
+
+(defun make-block-buffer ()
+  (make-array +block-octet-count+
+              :element-type '(unsigned-byte 8)
+              :initial-element 0))
+
+(defun read-header-block (buffer stream)
+  "Read a tar header block from STREAM into BUFFER. Returns NIL when
+at the terminating block of the end of input, BUFFER otherwise."
+  (let ((size (read-sequence buffer stream)))
+    (cond ((zerop size)
+           nil)
+          ((/= size 0 +block-octet-count+)
+           (error "Short block (only ~D bytes)" size))
+          ((every #'zerop buffer)
+           nil)
+          (t
+           buffer))))
+
+(defun ascii-subseq (vector start end)
+  (let ((string (make-string (- end start))))
+    (loop for i from 0
+          for j from start below end
+          do (setf (char string i) (code-char (aref vector j))))
+    string))
+
+(defun block-asciiz-string (block start length)
+  (let* ((end (+ start length))
+         (eos (or (position 0 block :start start :end end)
+                            end)))
+    (ascii-subseq block start eos)))
+
+(defun payload-size (header)
+  (values (parse-integer (block-asciiz-string header 124 12) :radix 8)))
+
+(defun file-payload-p (header)
+  (member (aref header 156) '(0 48)))
+
+(defparameter *ignored-path-substrings*
+  '("/_darcs/" "/CVS/" "/.git/" "/CVS/" "/.hg/"))
+
+(defun ignored-path-p (path)
+  (dolist (substring *ignored-path-substrings*)
+    (when (search substring path)
+      (return t))))
+
+(defun prefix (header)
+  (when (plusp (aref header 345))
+    (block-asciiz-string header 345 155)))
+
+(defun name (header)
+  (block-asciiz-string header 0 100))
+
+(defun full-path (header)
+  (let ((prefix (prefix header))
+        (name (name header)))
+    (if prefix
+        (format nil "~A/~A" prefix name)
+        name)))
+
+(defun skip-n-octets-blocks (n stream)
+  (let ((count (ceiling n +block-octet-count+))
+        (block (make-block-buffer)))
+    (dotimes (i count)
+      (read-sequence block stream))))
+
+(defun content-info (stream)
+  "Return a list of file info for the POSIX tar stream STREAM. Each
+element in the result is a list of a filename, the position of its
+starting storage block in STREAM, and the total file size."
+  (file-position stream :start)
+  (let ((buffer (make-block-buffer))
+        (result '()))
+    (loop
+      (let ((header (read-header-block buffer stream))
+            (position (file-position stream)))
+        (when (not header)
+          (return result))
+        (let ((size (payload-size header)))
+          (when (file-payload-p header)
+            (let ((path (full-path header)))
+              (unless (ignored-path-p path)
+                (push (list path
+                            position
+                            size)
+                      result))))
+          (skip-n-octets-blocks size stream))))))
+
+(defun content-hash (tarfile)
+  "Return a hash string of TARFILE. The hash is computed by creating
+the digest of the files in TARFILE in order of their name."
+  (let ((temp "quicklisp-controller:tmp;tarhash.tar"))
+    (ensure-directories-exist temp)
+    (setf tarfile (gunzip tarfile temp))
+    (unwind-protect
+         (with-open-file (stream tarfile :element-type '(unsigned-byte 8))
+           (let* ((openssl (uiop:launch-program "openssl dgst -sha1"
+                                                :input :stream
+                                                :output :stream))
+                  (digest-stream (uiop:process-info-input openssl))
+                  (buffer (make-block-buffer)))
+             (flet ((add-file-content (position size)
+                      (file-position stream position)
+                      (multiple-value-bind (complete partial)
+                          (truncate size +block-octet-count+)
+                        (dotimes (i complete)
+                          (read-sequence buffer stream)
+                          (write-sequence buffer digest-stream))
+                        (read-sequence buffer stream)
+                        (write-sequence buffer digest-stream :end partial))))
+               (let ((contents (content-info stream)))
+                 (setf contents (sort contents #'string< :key #'first))
+                 (dolist (info contents)
+                   (destructuring-bind (position size)
+                       (rest info)
+                     (add-file-content position size))))
+               (close (uiop:process-info-input openssl))
+               (unless (zerop (uiop:wait-process openssl))
+                 (error "openssl failed to calculate sha1"))
+               (extract-openssl-digest (read-line (uiop:process-info-output openssl))))))
+      (when (probe-file temp)
+        (ignore-errors (delete-file temp))))))

--- a/content-hash.lisp
+++ b/content-hash.lisp
@@ -1,5 +1,33 @@
-;; copied from tarhash.lisp from quicklisp-controller: https://github.com/quicklisp/quicklisp-controller
-;; changed to use openssl to compute sha1 digest rather than depending on ironclad
+;;; Copyright (c) 2013 Zachary Beane <xach@xach.com>, All Rights Reserved
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions
+;;; are met:
+;;;
+;;;   * Redistributions of source code must retain the above copyright
+;;;     notice, this list of conditions and the following disclaimer.
+;;;
+;;;   * Redistributions in binary form must reproduce the above
+;;;     copyright notice, this list of conditions and the following
+;;;     disclaimer in the documentation and/or other materials
+;;;     provided with the distribution.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR 'AS IS' AND ANY EXPRESSED
+;;; OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+;;; WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+;;; DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+;;; GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+;;; WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+;;; Commentary:
+;;;
+;;; copied from tarhash.lisp from quicklisp-controller: https://github.com/quicklisp/quicklisp-controller
+;;; changed to use openssl to compute sha1 digest rather than depending on ironclad
 
 (in-package #:ql-https)
 

--- a/content-hash.lisp
+++ b/content-hash.lisp
@@ -95,8 +95,7 @@ starting storage block in STREAM, and the total file size."
 (defun content-hash (tarfile)
   "Return a hash string of TARFILE. The hash is computed by creating
 the digest of the files in TARFILE in order of their name."
-  (let ((temp "quicklisp-controller:tmp;tarhash.tar"))
-    (ensure-directories-exist temp)
+  (uiop:with-temporary-file (:pathname temp)
     (setf tarfile (gunzip tarfile temp))
     (unwind-protect
          (with-open-file (stream tarfile :element-type '(unsigned-byte 8))

--- a/ql-https.asd
+++ b/ql-https.asd
@@ -10,7 +10,8 @@
   :source-control (:git "https://github.com/rudolfochrist/ql-https.git")
   :version (:read-file-line "version")
   :depends-on ((:require "uiop") (:feature :sbcl :sb-md5))
-  :components ((:file "ql-https"))
+  :components ((:file "ql-https")
+               (:file "content-hash"))
   :description "Enable HTTPS in Quicklisp"
   :long-description
   #.(uiop:read-file-string


### PR DESCRIPTION
After exchange on reddit when ql-https release was posted there, I realize the sha1 provided doesn't come from git as I had thought for some reason, but is calculated by iterating over the files in the tgz sorted by filename and feeding each into the sha1 digest. This is done by quicklisp-controller using sha1 from ironclad, but as we are quicklisp client and not server side script, we shouldn't use dependencies so I took the code from quicklisp-controller and used `openssl dgst -sha1` instead of using ironclad. sha1 is much more expensive to generate collisions for than md5, so this should provide a meaningful increase in security in case quicklisp server is compromised, though it is still possible to generate collisions. It'd be great if quicklisp dist provided a secure hash like sha256 but I think this is the best we can check for now