### PR TITLE
Use https to download quicklisp's archive

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,7 @@ meta=$( curl -s https://beta.quicklisp.org/client/quicklisp.sexp | \
             awk '/:client-tar/,/)/' | tr '\n' ' ' | tr -s ' ' )
 
 url=$( perl -nle 'print $& if m{(?<=:url ")[^"]*}g' <<< "$meta" )
+[[ "$url" =~ ^http:// ]] && url="https${url#http}"
 sha256=$( perl -nle 'print $& if m{(?<=:sha256 ")[^"]*}g' <<< "$meta" )
 
 echo "Downloading quicklisp client..."


### PR DESCRIPTION
By default quicklisp uses http, this changes the url to https. No change happens if in future the url becomes https by default.

This can be achieved in multiple ways, this approach doesn't modify the existing code for simplicity.