### PR TITLE
WIP: add :after method for check-local-archive file

### DIFF
--- a/content-hash.lisp
+++ b/content-hash.lisp
@@ -61,7 +61,7 @@ at the terminating block of the end of input, BUFFER otherwise."
 (defun block-asciiz-string (block start length)
   (let* ((end (+ start length))
          (eos (or (position 0 block :start start :end end)
-                            end)))
+                  end)))
     (ascii-subseq block start eos)))
 
 (defun payload-size (header)
@@ -161,3 +161,41 @@ the digest of the files in TARFILE in order of their name."
                (extract-openssl-digest (read-binary-line (uiop:process-info-output openssl))))))
       (when (probe-file temp)
         (ignore-errors (delete-file temp))))))
+
+(defun content-hash-ultralisp (tarfile)
+  "Return a hash string of TARFILE. The hash is done with openssl, and done in
+the order in which Ultralisp expects the SHA to be computed (which is subtly
+different than standard quicklisp).
+
+Chiefly, Ultralisps processing is as follows:
+`tar -xOf <file>` into a sequence (via babel-streams) & process said
+sequence with ironclad.
+"
+  (let* ((tar
+           (uiop:launch-program
+            (list "tar" "-xOf" (namestring tarfile))
+            :output :stream
+            :element-type '(unsigned-byte 8)))
+         (openssl
+           (uiop:launch-program
+            (list "openssl" "dgst" "-sha1")
+            :input :stream
+            :output :stream
+            :element-type '(unsigned-byte 8)))
+         (tar-out (uiop:process-info-output tar))
+         (openssl-in (uiop:process-info-input openssl))
+         (buffer (make-array 8192 :element-type '(unsigned-byte 8))))
+    (unwind-protect
+         (loop
+           for count = (read-sequence buffer tar-out)
+           while (> count 0)
+           do (write-sequence buffer openssl-in :end count))
+      (close openssl-in))
+    (unless (zerop (uiop:wait-process tar))
+      (error "tar failed while extracting contents"))
+    (unless (zerop (uiop:wait-process openssl))
+      (error "openssl failed to calculate sha1"))
+
+    (extract-openssl-digest
+     (read-binary-line
+      (uiop:process-info-output openssl)))))

--- a/ql-https.asd
+++ b/ql-https.asd
@@ -29,6 +29,8 @@
      (uiop:subpathname *load-pathname* "README.md"))
   :perform (load-op :after (o c)
                     (uiop:symbol-call :ql-https :register-fetch-scheme-functions)
+                    (loop for f in (list :ql-https/quicklisp-check-sha1 :ql-https/ultralisp-check-sha1)
+                          do (setf *features* (delete f *features*)))
                     (pushnew :ql-https *features*))
   :in-order-to ((test-op (test-op "ql-https/test"))))
 

--- a/ql-https.asd
+++ b/ql-https.asd
@@ -1,5 +1,13 @@
 ;;;; ql-https.asd
 
+(dolist (dist (ql-dist:all-dists))
+  (let ((dist-name (slot-value dist 'ql-dist::name)))
+    (cond
+      ((string= dist-name "quicklisp")
+       (pushnew :ql-https/quicklisp-check-sha1 *features*))
+      ((string= dist-name "ultralisp")
+       (pushnew :ql-https/ultralisp-check-sha1 *features*)))))
+
 (defsystem "ql-https"
   :author "Sebastian Christ <rudolfo.christ@pm.me>"
   :maintainer "Sebastian Christ <rudolfo.christ@pm.me>"
@@ -9,7 +17,10 @@
   :bug-tracker "https://github.com/rudolfochrist/ql-https/issues"
   :source-control (:git "https://github.com/rudolfochrist/ql-https.git")
   :version (:read-file-line "version")
-  :depends-on ((:require "uiop") (:feature :sbcl :sb-md5))
+  :depends-on ((:require "uiop")
+               #+ql-https/ultralisp-check-sha1 (:require "ironclad")
+               #+ql-https/ultralisp-check-sha1 (:require "babel-streams")
+               (:feature :sbcl :sb-md5))
   :components ((:file "ql-https")
                (:file "content-hash"))
   :description "Enable HTTPS in Quicklisp"
@@ -36,5 +47,7 @@
 
 
 
+(loop for f in (list :ql-https/quicklisp-check-sha1 :ql-https/ultralisp-check-sha1)
+      do (setf *features* (delete f *features*)))
 
 

--- a/ql-https.asd
+++ b/ql-https.asd
@@ -3,8 +3,6 @@
 (dolist (dist (ql-dist:all-dists))
   (let ((dist-name (slot-value dist 'ql-dist::name)))
     (cond
-      ((string= dist-name "quicklisp")
-       (pushnew :ql-https/quicklisp-check-sha1 *features*))
       ((string= dist-name "ultralisp")
        (pushnew :ql-https/ultralisp-check-sha1 *features*)))))
 
@@ -29,7 +27,7 @@
      (uiop:subpathname *load-pathname* "README.md"))
   :perform (load-op :after (o c)
                     (uiop:symbol-call :ql-https :register-fetch-scheme-functions)
-                    (loop for f in (list :ql-https/quicklisp-check-sha1 :ql-https/ultralisp-check-sha1)
+                    (loop for f in (list :ql-https/ultralisp-check-sha1)
                           do (setf *features* (delete f *features*)))
                     (pushnew :ql-https *features*))
   :in-order-to ((test-op (test-op "ql-https/test"))))

--- a/ql-https.asd
+++ b/ql-https.asd
@@ -47,7 +47,5 @@
 
 
 
-(loop for f in (list :ql-https/quicklisp-check-sha1 :ql-https/ultralisp-check-sha1)
-      do (setf *features* (delete f *features*)))
 
 

--- a/ql-https.asd
+++ b/ql-https.asd
@@ -1,11 +1,5 @@
 ;;;; ql-https.asd
 
-(dolist (dist (ql-dist:all-dists))
-  (let ((dist-name (slot-value dist 'ql-dist::name)))
-    (cond
-      ((string= dist-name "ultralisp")
-       (pushnew :ql-https/ultralisp-check-sha1 *features*)))))
-
 (defsystem "ql-https"
   :author "Sebastian Christ <rudolfo.christ@pm.me>"
   :maintainer "Sebastian Christ <rudolfo.christ@pm.me>"
@@ -16,8 +10,6 @@
   :source-control (:git "https://github.com/rudolfochrist/ql-https.git")
   :version (:read-file-line "version")
   :depends-on ((:require "uiop")
-               #+ql-https/ultralisp-check-sha1 (:require "ironclad")
-               #+ql-https/ultralisp-check-sha1 (:require "babel-streams")
                (:feature :sbcl :sb-md5))
   :components ((:file "ql-https")
                (:file "content-hash"))
@@ -27,8 +19,6 @@
      (uiop:subpathname *load-pathname* "README.md"))
   :perform (load-op :after (o c)
                     (uiop:symbol-call :ql-https :register-fetch-scheme-functions)
-                    (loop for f in (list :ql-https/ultralisp-check-sha1)
-                          do (setf *features* (delete f *features*)))
                     (pushnew :ql-https *features*))
   :in-order-to ((test-op (test-op "ql-https/test"))))
 

--- a/ql-https.lisp
+++ b/ql-https.lisp
@@ -98,6 +98,7 @@ dist."
     (unless (= (ql-dist:archive-size release) (file-size file))
       (error "file size mismatch for ~A" name))))
 
+#+ql-https/ultralisp-check-sha1
 (defun content-hash-ultralisp (tarfile)
   (let* ((octets (babel-streams:with-output-to-sequence (buffer)
                    (uiop:run-program
@@ -131,7 +132,9 @@ dist."
     (let* ((archive-sha1 (ql-dist:archive-content-sha1 release))
            (ql-dist-name (slot-value (slot-value release 'ql-dist:dist) 'ql-dist:name))
            (expected (case ql-dist-name
+                       #+ql-https/quicklisp-check-sha1
                        ("quicklisp" (content-hash file))
+                       #+ql-https/ultralisp-check-sha1
                        ("ultralisp" (content-hash-ultralisp file))
                        (t nil))))
       (when (and expected (not (string-equal archive-sha1 expected)))

--- a/ql-https.lisp
+++ b/ql-https.lisp
@@ -129,9 +129,8 @@ dist."
       (error "md5 mismatch for ~A" name))
 
     (let* ((archive-sha1 (ql-dist:archive-content-sha1 release))
-           (ql-dist-name (ql-dist:name (ql-dist:release 'ql-dist:dist)))
+           (ql-dist-name (ql-dist:name (ql-dist:dist release)))
            (expected (case ql-dist-name
-                       #+ql-https/quicklisp-check-sha1
                        ("quicklisp" (content-hash file))
                        #+ql-https/ultralisp-check-sha1
                        ("ultralisp" (content-hash-ultralisp file))

--- a/ql-https.lisp
+++ b/ql-https.lisp
@@ -102,8 +102,7 @@ dist."
 (defun content-hash-ultralisp (tarfile)
   (let* ((octets (babel-streams:with-output-to-sequence (buffer)
                    (uiop:run-program
-                    (apply #'concatenate
-                           'string (list "tar -xOf" (namestring tarfile)))
+                    (list "tar -xOf" (namestring tarfile))
                     :output buffer)))
 
          ;; (openssl-sha1
@@ -130,7 +129,7 @@ dist."
       (error "md5 mismatch for ~A" name))
 
     (let* ((archive-sha1 (ql-dist:archive-content-sha1 release))
-           (ql-dist-name (slot-value (slot-value release 'ql-dist:dist) 'ql-dist:name))
+           (ql-dist-name (ql-dist:name (ql-dist:release 'ql-dist:dist)))
            (expected (case ql-dist-name
                        #+ql-https/quicklisp-check-sha1
                        ("quicklisp" (content-hash file))

--- a/ql-https.lisp
+++ b/ql-https.lisp
@@ -98,6 +98,16 @@ dist."
     (unless (= (ql-dist:archive-size release) (file-size file))
       (error "file size mismatch for ~A" name))))
 
+(defmethod ql-dist:check-local-archive-file :after ((release ql-dist:release))
+    "Checks that the md5 and size of FILE are as expected from the quicklisp
+dist."
+  (let ((name (ql-dist:name release))
+        (file (ql-dist:local-archive-file release)))
+    (unless (string-equal (ql-dist:archive-md5 release) (md5 file))
+      (error "md5 mismatch for ~A" name))
+    (unless (string-equal (ql-dist:archive-content-sha1 release) (content-hash file))
+      (error "sha1 mismatch for ~A" name))))
+
 (defun register-fetch-scheme-functions ()
   (setf ql-http:*fetch-scheme-functions*
         (list (cons "http" 'fetcher)

--- a/ql-https.lisp
+++ b/ql-https.lisp
@@ -98,27 +98,6 @@ dist."
     (unless (= (ql-dist:archive-size release) (file-size file))
       (error "file size mismatch for ~A" name))))
 
-#+ql-https/ultralisp-check-sha1
-(defun content-hash-ultralisp (tarfile)
-  (let* ((octets (babel-streams:with-output-to-sequence (buffer)
-                   (uiop:run-program
-                    (list "tar -xOf" (namestring tarfile))
-                    :output buffer)))
-
-         ;; (openssl-sha1
-         ;;   (uiop:launch-program "openssl dgst -sha1"
-         ;;                        :input (copy-seq octets)
-         ;;                        :element-type '(unsigned-byte 8)
-         ;;                        :output :stream))
-         )
-    ;; (print
-    ;;  (extract-openssl-digest
-    ;;   (read-binary-line
-    ;;    (uiop:process-info-output openssl-sha1))))
-
-    (ironclad:byte-array-to-hex-string
-     (ironclad:digest-sequence :sha1 (copy-seq octets)))))
-
 (defmethod ql-dist:check-local-archive-file :after ((release ql-dist:release))
   "Checks that the md5 and size of FILE are as expected from the quicklisp
 dist."
@@ -132,7 +111,6 @@ dist."
            (ql-dist-name (ql-dist:name (ql-dist:dist release)))
            (expected (case ql-dist-name
                        ("quicklisp" (content-hash file))
-                       #+ql-https/ultralisp-check-sha1
                        ("ultralisp" (content-hash-ultralisp file))
                        (t nil))))
       (when (and expected (not (string-equal archive-sha1 expected)))


### PR DESCRIPTION
This is an initial test of the solution proposed in:

https://github.com/rudolfochrist/ql-https/issues/14

What is odd is that the md5sum checksum succeeds, yet the sha1sum fails.