### PR TITLE
ql-https.lisp ~ rewrite verify-download to be a CLOS `:after` method

### DIFF
--- a/ql-https.lisp
+++ b/ql-https.lisp
@@ -38,8 +38,6 @@
                                        :error-output :output))
              (file (and file (probe-file file)))
              (release (url-to-release url)))
-        (when release
-          (verify-download file release))
         (values output file))
       (restart-case
           (handler-bind ((no-https-error (lambda (c)
@@ -92,14 +90,15 @@
   (with-open-file (f file)
     (file-length f)))
 
-(defun verify-download (file name)
+(defmethod ql-dist:check-local-archive-file :after ((release ql-dist:release))
   "Checks that the md5 and size of FILE are as expected from the quicklisp
 dist."
-  (let ((release (ql-dist:find-release name)))
-    (unless (= (ql-dist:archive-size release) (file-size file))
-      (error "file size mismatch for ~A" name))
+  (let ((name (ql-dist:name release))
+        (file (ql-dist:local-archive-file release)))
+
     (unless (string-equal (ql-dist:archive-md5 release) (md5 file))
       (error "md5 mismatch for ~A" name))
+
     (unless (member (ql-dist:archive-content-sha1 release)
                     (list (content-hash file (lambda (c) (sort c #'string< :key #'first)))
                           (content-hash file #'reverse))


### PR DESCRIPTION
This hooks directly into `ql-dist:check-local-archive-file`, and will perform our checks of the file at exactly the right time (after ql-dist does its own internal checks of the archive file).

As a result we don't have to check the file size ourself, nor lookup the release.