### PR TITLE
Allow defining *QUICKLISP-HOME* in the REPL.

### DIFF
--- a/ql-setup.lisp
+++ b/ql-setup.lisp
@@ -24,6 +24,9 @@
 ;; Whenever the client is updated the setup.lisp is replaced
 ;; and contains the call to setup.
 
+(in-package #:common-lisp-user)
+(export '*quicklisp-home*)
+
 (defpackage #:ql-setup
   (:use #:cl)
   (:export #:*quicklisp-home*
@@ -38,6 +41,8 @@
 (defvar *quicklisp-home*
   (make-pathname :name nil :type nil
                  :defaults (let ((qlhome "~/quicklisp/"))
+                             (when (boundp 'cl-user:*quicklisp-home*)
+                               (setf qlhome cl-user:*quicklisp-home*))
                              (if (probe-file qlhome)
                                  qlhome
                                  (error "Quicklisp not installed to


### PR DESCRIPTION
Allows users to define *QUICKLISP-HOME* in the REPL before loading ql-setup.lisp; which makes it easier to install it to a different directory.